### PR TITLE
update links to blog posts on gaze home page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -35,7 +35,7 @@
 <h2>Overview</h2>
 
 <p>There is general information about Gaze in the 
-<a href="http://www.mysociety.org/?p=83">blog post which announced its launch</a>,
+<a href="https://www.mysociety.org/2005/09/15/gaze-web-service/">blog post which announced its launch</a>,
 and another <a href="https://www.mysociety.org/2005/11/30/population-density-and-customary-proximity/">blog post about population density</a>.
 
 <h2>Language specific APIs</h2>

--- a/web/index.html
+++ b/web/index.html
@@ -36,7 +36,7 @@
 
 <p>There is general information about Gaze in the 
 <a href="http://www.mysociety.org/?p=83">blog post which announced its launch</a>,
-and another <a href="http://www.mysociety.org/?p=96">blog post about population density</a>.
+and another <a href="https://www.mysociety.org/2005/11/30/population-density-and-customary-proximity/">blog post about population density</a>.
 
 <h2>Language specific APIs</h2>
 


### PR DESCRIPTION
URLs on mySociety's blog have changed over time :-)
One of the links on was redirecting (301), but the other
was broken (404). This fixes them both to use the current
blog URLs.
